### PR TITLE
Display performance information upon callback exit

### DIFF
--- a/TheAaronSheet.js
+++ b/TheAaronSheet.js
@@ -287,9 +287,11 @@ var TAS = TAS || (function(){
             /*jshint -W054 */
             return new Function('cb','ctx','TASlog',
                 "return function TAS_CALLSTACK_"+ctxref+"(){"+
-                    "TASlog('Entering: '+(cb.name||'(anonymous function)'));"+
+                    "TASlog('Entering: '+(cb.name||'(anonymous function)'));" +
+					"var t0 = performance.now();" +
                     "cb.apply(ctx||{},arguments);"+
-                    "TASlog('Exiting: '+(cb.name||'(anonymous function)'));"+
+					"var t1 = performance.now();" +
+                    "TASlog('Exiting: '+(cb.name||'(anonymous function)')+' (took '+Number(Math.round((t1-t0)+'e3')+'e-3')+' ms)');" + "};" +
                 "};")(cb,ctx,log);
             /*jshint +W054 */
         }(callback,context,callstack,label));

--- a/TheAaronSheet.js
+++ b/TheAaronSheet.js
@@ -287,10 +287,10 @@ var TAS = TAS || (function(){
             /*jshint -W054 */
             return new Function('cb','ctx','TASlog',
                 "return function TAS_CALLSTACK_"+ctxref+"(){"+
-                    "TASlog('Entering: '+(cb.name||'(anonymous function)'));" +
-					"var t0 = performance.now();" +
+                    "TASlog('Entering: '+(cb.name||'(anonymous function)'));"+
+                    "var t0 = performance.now();" +
                     "cb.apply(ctx||{},arguments);"+
-					"var t1 = performance.now();" +
+                    "var t1 = performance.now();" +
                     "TASlog('Exiting: '+(cb.name||'(anonymous function)')+' (took '+Number(Math.round((t1-t0)+'e3')+'e-3')+' ms)');" + "};" +
                 "};")(cb,ctx,log);
             /*jshint +W054 */


### PR DESCRIPTION
This will display the time spent in the function referenced by TAS.callback().

Example:
 TAS:  Entering: eventSheetOpened 
 TAS:  Exiting: eventSheetOpened (took 1.635 ms) 
